### PR TITLE
Add checks for ... and st_read

### DIFF
--- a/R/read.R
+++ b/R/read.R
@@ -83,14 +83,14 @@ oe_read = function(
     # use names(formals("st_read.character", envir = getNamespace("sf")))
     any(
       names(list(...)) %!in%
-      names(formals("st_read.character", envir = getNamespace("sf")))
+      names(formals(get("st_read.character", envir = getNamespace("sf"))))
     )
   ) {
     warning(
       "The following arguments are probably misspelled: ",
       setdiff(
         names(list(...)),
-        names(formals("st_read.character", envir = getNamespace("sf")))
+        names(formals(get("st_read.character", envir = getNamespace("sf"))))
       ),
       call. = FALSE,
       immediate. = TRUE

--- a/R/read.R
+++ b/R/read.R
@@ -68,6 +68,29 @@ oe_read = function(
   quiet = TRUE
 ) {
 
+  # See https://github.com/ITSLeeds/osmextract/issues/114
+  if (
+    # The following condition checks if the user passed down one or more
+    # arguments using ...
+    ...length() > 0L &&
+    # At the moment, the only function that uses ... is sf::st_read, so I'm
+    # going to check which arguments in ... are not inlucded in the formals of
+    # sf::st_read. Moreover, at the moment, oe_read will always use
+    # sf:::st_read.character, so I will check the formals of that method.
+    any(
+      names(list(...)) %!in% names(formals(sf:::st_read.character))
+    )
+  ) {
+    methods(sf::st_read)
+    warning(
+      "The following arguments are probably misspelled: ",
+      setdiff(names(list(...)), names(formals(sf:::st_read.character))),
+      call. = FALSE,
+      immediate. = TRUE
+    )
+  }
+
+
   # If the input file_path is an existing .gpkg file is the easiest case since
   # we only need to read it:
   if (file.exists(file_path) && tools::file_ext(file_path) == "gpkg") {

--- a/R/read.R
+++ b/R/read.R
@@ -73,18 +73,25 @@ oe_read = function(
     # The following condition checks if the user passed down one or more
     # arguments using ...
     ...length() > 0L &&
-    # At the moment, the only function that uses ... is sf::st_read, so I'm
-    # going to check which arguments in ... are not inlucded in the formals of
-    # sf::st_read. Moreover, at the moment, oe_read will always use
-    # sf:::st_read.character, so I will check the formals of that method.
+    # At the moment, the only function that uses ... is sf::st_read, so I can
+    # simply check which arguments in ... are not inlucded in the formals of
+    # sf::st_read. Moreover, st_read should always use sf:::st_read.character,
+    # so I need to check the formals of that method.
+    #
+    # The classical way should be names(formals(sf:::st_read.character)), but it
+    # returns a notes in the R CMD checks related to :::. Hence, I decided to
+    # use names(formals("st_read.character", envir = getNamespace("sf")))
     any(
-      names(list(...)) %!in% names(formals(sf:::st_read.character))
+      names(list(...)) %!in%
+      names(formals("st_read.character", envir = getNamespace("sf")))
     )
   ) {
-    methods(sf::st_read)
     warning(
       "The following arguments are probably misspelled: ",
-      setdiff(names(list(...)), names(formals(sf:::st_read.character))),
+      setdiff(
+        names(list(...)),
+        names(formals("st_read.character", envir = getNamespace("sf")))
+      ),
       call. = FALSE,
       immediate. = TRUE
     )


### PR DESCRIPTION
Previously: 

``` r
remotes::install_github("ITSLeeds/osmextract")
library(osmextract)
oe_get("Isle of Wight", stringAsFactor = TRUE)
#> Error in st_sf(x, ..., agr = agr, sf_column_name = sf_column_name): no simple features geometry column present
```

<sup>Created on 2020-10-21 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

Now: 

``` r
remotes::install_github("ITSLeeds/osmextract", "test_ellipsis")
library(osmextract)
oe_get("Isle of Wight", stringAsFactor = TRUE)
#> Warning: The following arguments are probably misspelled: stringAsFactor
#> Error in st_sf(x, ..., agr = agr, sf_column_name = sf_column_name): no simple features geometry column present
```

<sup>Created on 2020-10-21 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

I'm not a big fan of the current solution since it's (probably) unnecessarily complicated but I couldn't think of any simpler approach. 

